### PR TITLE
Add new columns greenspace_site_id as an alias of id

### DIFF
--- a/greenspace_typology_2018.sql
+++ b/greenspace_typology_2018.sql
@@ -29,7 +29,7 @@ CLUSTER sidx_garden ON os.os_mm_private_gardens;
 ----STEP 2: make os.greenspace_no_private_gardens from greenspace_mm_wales instead of mm_gs_unified_spaces
 ---------------------------
 
-CREATE TABLE os.greenspace_no_private_gardens AS SELECT * FROM bgs.os_greenspace_mm_wales
+CREATE TABLE os.greenspace_no_private_gardens AS SELECT *, id as greenspace_site_id FROM bgs.os_greenspace_mm_wales
 WHERE prifunc NOT IN ('Private Garden');
 
 


### PR DESCRIPTION
This bit of code saves you having to rename the column `id` to `greenspace_site_id` manually. And keeps the original `id` column, in case somewhere else in the code that column is needed.